### PR TITLE
Adding node scanner metrics

### DIFF
--- a/source/monitoring/metrics-alerts/minio-metrics-and-alerts.rst
+++ b/source/monitoring/metrics-alerts/minio-metrics-and-alerts.rst
@@ -303,6 +303,26 @@ Node Metrics
 
    Uptime for MinIO process per node in seconds.
 
+.. metric:: minio_node_scanner_bucket_scans_finished
+
+   Total number of bucket scans finished since server start.
+
+.. metric:: minio_node_scanner_bucket_scans_started
+
+   Total number of bucket scans started since server start.
+
+.. metric:: minio_node_scanner_directories_scanned
+
+   Total number of directories scanned since server start.
+
+.. metric:: minio_node_scanner_objects_scanned
+
+   Total number of unique objects scanned since server start.
+
+.. metric:: minio_node_scanner_versions_scanned
+
+   Total number of object versions scanned since server start.
+
 .. metric:: minio_node_syscall_read_total
 
    Total read SysCalls to the kernel. ``/proc/[pid]/io syscr``


### PR DESCRIPTION
This closes #504 .

Adds five new metrics to the Node section of the Metrics and Alerts page related to `minio_node_scanner`.