### PR TITLE
Remove underscore from webhook endpoint env var example

### DIFF
--- a/source/administration/monitoring/publish-events-to-webhook.rst
+++ b/source/administration/monitoring/publish-events-to-webhook.rst
@@ -59,14 +59,14 @@ variables *or* by setting runtime configuration settings.
       .. code-block:: shell
          :class: copyable
 
-         set MINIO_NOTIFY_WEBHOOK_ENABLE_<IDENTIFIER>_="on"
-         set MINIO_NOTIFY_WEBHOOK_ENDPOINT_<IDENTIFIER>_="ENDPOINT"
-         set MINIO_NOTIFY_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>_="<string>"
-         set MINIO_NOTIFY_WEBHOOK_QUEUE_DIR_<IDENTIFIER>_="<string>"
-         set MINIO_NOTIFY_WEBHOOK_QUEUE_LIMIT_<IDENTIFIER>_="<string>"
-         set MINIO_NOTIFY_WEBHOOK_CLIENT_CERT_<IDENTIFIER>_="<string>"
-         set MINIO_NOTIFY_WEBHOOK_CLIENT_KEY_<IDENTIFIER>_="<string>"
-         set MINIO_NOTIFY_WEBHOOK_COMMENT_<IDENTIFIER>_="<string>"
+         set MINIO_NOTIFY_WEBHOOK_ENABLE_<IDENTIFIER>="on"
+         set MINIO_NOTIFY_WEBHOOK_ENDPOINT_<IDENTIFIER>="ENDPOINT"
+         set MINIO_NOTIFY_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_WEBHOOK_QUEUE_DIR_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_WEBHOOK_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_WEBHOOK_CLIENT_CERT_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_WEBHOOK_CLIENT_KEY_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_WEBHOOK_COMMENT_<IDENTIFIER>="<string>"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
         Webhook service endpoint. Use the same ``<IDENTIFIER>`` value for all 


### PR DESCRIPTION
The webhook endpoint variable example on the Publish Events to Webhook page has an extra underscore at the end of the variable names. (After `<IDENTIFIER>`.) Remove them so the example is correct.

Fixes https://github.com/minio/docs/issues/744