### PR TITLE
Indicate Postgres schema requirement

### DIFF
--- a/source/administration/monitoring/publish-events-to-postgresql.rst
+++ b/source/administration/monitoring/publish-events-to-postgresql.rst
@@ -57,7 +57,7 @@ variables *or* by setting runtime configuration settings.
       :mc:`minio server` process applies the specified settings on its 
       next startup.
       
-      The following example code sets *all*  environment variables
+      The following example code sets *all* environment variables
       related to configuring a PostgreSQL service endpoint. The minimum
       *required* variables are:
       
@@ -71,7 +71,7 @@ variables *or* by setting runtime configuration settings.
             :class: copyable
          
                set MINIO_NOTIFY_POSTGRES_ENABLE_<IDENTIFIER>="on"
-               set MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_<IDENTIFIER>="host=postgresql-endpoint.example.net port=4222"
+               set MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_<IDENTIFIER>="options='-c search_path=minio' host=postgresql-endpoint.example.net port=4222"
                set MINIO_NOTIFY_POSTGRES_TABLE_<IDENTIFIER>="minioevents"
                set MINIO_NOTIFY_POSTGRES_FORMAT_<IDENTIFIER>="namespace|access"
                set MINIO_NOTIFY_POSTGRES_MAX_OPEN_CONNECTIONS_<IDENTIFIER>="2"
@@ -85,7 +85,7 @@ variables *or* by setting runtime configuration settings.
             :class: copyable
 
                export MINIO_NOTIFY_POSTGRES_ENABLE_<IDENTIFIER>="on"
-               export MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_<IDENTIFIER>="host=postgresql-endpoint.example.net port=4222"
+               export MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_<IDENTIFIER>="options='-c search_path=minio' host=postgresql-endpoint.example.net port=4222"
                export MINIO_NOTIFY_POSTGRES_TABLE_<IDENTIFIER>="minioevents"
                export MINIO_NOTIFY_POSTGRES_FORMAT_<IDENTIFIER>="namespace|access"
                export MINIO_NOTIFY_POSTGRES_MAX_OPEN_CONNECTIONS_<IDENTIFIER>="2"


### PR DESCRIPTION
https://min.io/docs/minio/linux/reference/minio-server/settings/notifications/postgresql.html#minio-server-envvar-bucket-notification-postgresql

It seems that minio previously inferred the db schema from the string passed e.g. `minio.minioevents`, however. In the current minio server, we need to independently specify a db schema in order to setup postgres notifications else we hit `pq: no schema has been selected to create in (*pq.Error)`. I believe that the documentation should change to reflect this.

@Docs team:  Please help me communicate this appropriately. Some more documentation is needed to make this clear.

@Ravind This is the commit which introduced the change. https://github.com/minio/minio/commit/701da1282a50b05488dc02031e8eda5d16c59606 - this is the release https://github.com/minio/minio/releases/tag/RELEASE.2024-04-28T17-53-50Z

I understand the commit is for further sanitization of the sql inputs - however it also forces the user to perform the above command modifications.

e.g.
```
export MINIO_NOTIFY_POSTGRES_ENABLE_PRIMARY="on"
export MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_PRIMARY="host=localhost port=5432 dbname=postgres user=postgres password=postgres sslmode=disable options='-c search_path=minio'"
export MINIO_NOTIFY_POSTGRES_TABLE_PRIMARY="minioevents"
export MINIO_NOTIFY_POSTGRES_FORMAT_PRIMARY="namespace"
export MINIO_NOTIFY_POSTGRES_MAX_OPEN_CONNECTIONS_PRIMARY="2"
export MINIO_NOTIFY_POSTGRES_COMMENT_PRIMARY="PostgreSQL Notification Event Logging for MinIO"
```
or 
```
mc admin config set <alias> --insecure notify_postgres:PRIMARY \
enable="on" \
connection_string="host=localhost port=5432 dbname=postgres user=postgres password=postgres options='-c search_path=minio' sslmode=disable" \
table="minioevents" \
format="namespace" \
max_open_connections="2" \
comment="PostgreSQL Notification Event Logging for MinIO"
```