### PR TITLE
fix: fixes build with minio v3 metrics

### DIFF
--- a/source/operations/monitoring/metrics-and-alerts.rst
+++ b/source/operations/monitoring/metrics-and-alerts.rst
@@ -31,6 +31,11 @@ Version 3 Endpoints
 For metrics version 3, all metrics are available under the base ``/minio/metrics/v3`` endpoint.
 You can scrape the base endpoint to collect all metrics in a single operation, or append an optional path to return a specific category.
 
+.. important:: 
+
+   The V3 metrics on this page may have gaps, inaccuracies, or incorrect information.
+   Reference the `minio/minio <https://github.com/minio/minio>`_ repository and review the source code for the most accurate representation of metrics as available.
+
 For example, the following endpoint returns audit metrics:
 
 .. code-block:: shell

--- a/sync-minio-server-docs.sh
+++ b/sync-minio-server-docs.sh
@@ -21,7 +21,7 @@ function main() {
 
    # Get the full list
 
-   curl --retry 10 -Ls https://raw.githubusercontent.com/minio/minio/master/docs/metrics/v3.md | csplit - /"## Metric Categories"/
+   curl --retry 10 -Ls https://raw.githubusercontent.com/minio/minio/3a0cc6c86e6d0c500d8f1f508ffde8152efb8c7e/docs/metrics/v3.md | csplit - /"## Metric Categories"/
 
    # Ignore xx00, contains intro text
    # Overwritten in second csplit anyway


### PR DESCRIPTION
Don´t delete v3 metrics just pull previous commit.

fixes: https://github.com/minio/docs/issues/1510