### PR TITLE
Correct duplicate word in retrieval support note

### DIFF
--- a/source/administration/object-management.rst
+++ b/source/administration/object-management.rst
@@ -143,7 +143,7 @@ The specific client behavior on write, list, get, or :ref:`delete <minio-object-
    * - ``GET`` (Read)
      - Retrieve the latest version of the object by default
 
-       Supports retrieving retrieving any object version by version ID.
+       Supports retrieving any object version by version ID.
      - Retrieve the object
 
    * - ``LIST`` (Read)


### PR DESCRIPTION
Removed the duplicate word "retrieving" under the GET (Read) row for Versioning Enabled.

Before:
> "Supports retrieving retrieving any object version by version ID."

After:
> "Supports retrieving any object version by version ID."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the object versioning documentation for the “Versioning Enabled | Suspended” column, removing a duplicated word in the description of retrieving object versions by version ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->